### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 selenium
 requests
-sqlalchemy


### PR DESCRIPTION
Removed SQL alchemy from the requirements. This was added in a previous version which intended to use it. We no longer do.